### PR TITLE
Add --remote-dbname option to avoid hardcoding 'cmonitor' influxDB da…

### DIFF
--- a/src/cmonitor.h
+++ b/src/cmonitor.h
@@ -198,6 +198,7 @@ public:
     // remove streaming opts
     std::string m_strRemoteAddress; // --remote-ip
     std::string m_strRemoteSecret; // --remote-secret
+    std::string m_strRemoteDatabaseName = "cmonitor"; // remote-dbname
     uint64_t m_nRemotePort = 0; // --remote-port
 
     // data collecting options

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,7 @@ struct option g_long_opts[] = {
     { "remote-ip", required_argument, 0, 'i' }, // force newline
     { "remote-port", required_argument, 0, 'p' }, // force newline
     { "remote-secret", required_argument, 0, 'X' }, // force newline
+    { "remote-dbname", required_argument, 0, 'D' }, // force newline
 
     // Other options
     { "version", no_argument, 0, 'v' }, // force newline
@@ -137,12 +138,13 @@ struct option_extended {
     { "Options to stream data remotely", &g_long_opts[11], "Port used by InfluxDB." },
     { "Options to stream data remotely", &g_long_opts[12],
         "Set the InfluxDB collector secret (by default use environment variable CMONITOR_SECRET).\n" },
+    { "Options to stream data remotely", &g_long_opts[13], "Set the InfluxDB database name.\n" },
 
     // help
-    { "Other options", &g_long_opts[13], "Show version and exit" }, // force newline
-    { "Other options", &g_long_opts[14],
+    { "Other options", &g_long_opts[14], "Show version and exit" }, // force newline
+    { "Other options", &g_long_opts[15],
         "Enable debug mode; automatically activates --foreground mode" }, // force newline
-    { "Other options", &g_long_opts[15], "Show this help" },
+    { "Other options", &g_long_opts[16], "Show this help" },
 
     { NULL, NULL, NULL }
 };
@@ -492,6 +494,9 @@ void CMonitorCollectorApp::parse_args(int argc, char** argv)
             case 'X':
                 g_cfg.m_strRemoteSecret = optarg;
                 break;
+            case 'D':
+                g_cfg.m_strRemoteDatabaseName = optarg;
+                break;
 
             // help
             case 'v':
@@ -652,7 +657,7 @@ int CMonitorCollectorApp::run(int argc, char** argv)
     g_output.init_json_output_file(g_cfg.m_strOutputFilenamePrefix);
     if (!g_cfg.m_strRemoteAddress.empty() && g_cfg.m_nRemotePort != 0) {
         /* We are attempting sending the data remotely */
-        g_output.init_influxdb_connection(g_cfg.m_strRemoteAddress, g_cfg.m_nRemotePort);
+        g_output.init_influxdb_connection(g_cfg.m_strRemoteAddress, g_cfg.m_nRemotePort, g_cfg.m_strRemoteDatabaseName);
     }
 
     if (!g_cfg.m_bForeground) {

--- a/src/output_frontend.cpp
+++ b/src/output_frontend.cpp
@@ -88,20 +88,21 @@ std::string hostname_to_ip(const std::string& hostname)
     return "";
 }
 
-void CMonitorOutputFrontend::init_influxdb_connection(const std::string& hostname, unsigned int port)
+void CMonitorOutputFrontend::init_influxdb_connection(
+    const std::string& hostname, unsigned int port, const std::string& dbname)
 {
     std::string ipaddress = hostname_to_ip(hostname);
     if (ipaddress.empty()) {
         char buf[1024];
         herror(buf);
-        fprintf(stderr, "hostname=%s to IP address convertion failed, bailing out: %s\n", hostname.c_str(), buf);
+        fprintf(stderr, "Lookup of IP address for hostname %s failed, bailing out: %s\n", hostname.c_str(), buf);
         exit(98);
     }
 
     m_influxdb_client_conn = new influx_client_t();
     m_influxdb_client_conn->host = strdup(ipaddress.c_str()); // force newline
     m_influxdb_client_conn->port = port; // force newline
-    m_influxdb_client_conn->db = strdup("cmonitor"); // force newline
+    m_influxdb_client_conn->db = strdup(dbname.c_str()); // force newline
     m_influxdb_client_conn->usr = strdup("usr"); // force newline
     m_influxdb_client_conn->pwd = strdup("pwd"); // force newline
 

--- a/src/output_frontend.h
+++ b/src/output_frontend.h
@@ -71,7 +71,7 @@ public:
     //------------------------------------------------------------------------------
 
     void init_json_output_file(const std::string& filenamePrefix);
-    void init_influxdb_connection(const std::string& hostname, unsigned int port);
+    void init_influxdb_connection(const std::string& hostname, unsigned int port, const std::string& dbname);
     void enable_json_pretty_print();
 
     //------------------------------------------------------------------------------


### PR DESCRIPTION
…tabase name