### PR TITLE
cgroup v2 CPU & memory stats for correct chart generation

### DIFF
--- a/collector/src/cgroups_cpuacct.cpp
+++ b/collector/src/cgroups_cpuacct.cpp
@@ -35,8 +35,12 @@
 
 bool CMonitorCgroups::read_cpuset_cpus(std::string kernelPath, std::set<uint64_t>& cpus)
 {
-    std::set<uint64_t> empty_set;
-    return read_integers_with_range_validation(kernelPath + "/cpuset.cpus", 0, INT32_MAX, cpus);
+    if (m_nCGroupsFound == CG_NONE)
+        return false;
+
+    std::string cpuset_path = kernelPath + ((m_nCGroupsFound == CG_VERSION2)? "/cpuset.cpus.effective" : "/cpuset.cpus");
+
+    return read_integers_with_range_validation(cpuset_path, 0, INT32_MAX, cpus);
 }
 
 bool CMonitorCgroups::read_cpuacct_line(FastFileReader& reader, std::vector<uint64_t>& valuesINT /* OUT */)

--- a/collector/src/cgroups_memory.cpp
+++ b/collector/src/cgroups_memory.cpp
@@ -192,16 +192,14 @@ void CMonitorCgroups::sample_memory(
     case CG_VERSION2: {
         key_value_map_t newEventsValues;
         if (sample_flat_keyed_file(m_cgroup_memory_v2_events, allowedStatsNames, "events.", newEventsValues)) {
-            if (print) {
-                for (auto entry : newEventsValues) {
-                    auto prevValue = m_memory_prev_values.v2_events.find(entry.first);
-                    if (prevValue != m_memory_prev_values.v2_events.end())
-                        m_pOutput->plong(entry.first.c_str(), entry.second - prevValue->second);
-                }
-
-                // save new values for next sample:
-                m_memory_prev_values.v2_events = newEventsValues;
+            for (auto entry : newEventsValues) {
+                auto prevValue = m_memory_prev_values.v2_events.find(entry.first);
+                if (print && prevValue != m_memory_prev_values.v2_events.end())
+                    m_pOutput->plong(entry.first.c_str(), entry.second - prevValue->second);
             }
+
+            // save new values for next sample:
+            m_memory_prev_values.v2_events = newEventsValues;
         }
     } break;
 

--- a/collector/src/main.cpp
+++ b/collector/src/main.cpp
@@ -879,6 +879,8 @@ int CMonitorCollectorApp::run_main_loop()
         charted_stats_from_cgroup_memory_v1.insert("failcnt");
         // cgroups v2
         charted_stats_from_cgroup_memory_v2.insert("stat.anon");
+        charted_stats_from_cgroup_memory_v2.insert("stat.file");
+        charted_stats_from_cgroup_memory_v2.insert("events.oom_kill");
     }
     // else: leave empty
 


### PR DESCRIPTION
cgroup v2 CPU & Memory stats for correct chart generation
* The CPU set is located at "/cpuset.cpus.effective" for cgroup v2
* Added 'file' and 'oom_kill' stats for memory chart to generate correctly