### PR TITLE
Test docker build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
     - name: run unit tests
       run: make test PROMETHEUS_SUPPORT=0
 
+  # this step is useful to check that the Dockerfile still works fine
   alpine_docker_image_creation:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,9 +57,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build Docker image (no push)
-      # see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets
-      # for the reason why DependaBot pull requests have no access to secrets like ${{ secrets.PAT_TOKEN_FOR_GITHUB }}
-      # if: ${{ github.actor == 'dependabot[bot]' }}
       uses: mr-smithers-excellent/docker-build-push@v6
       with:
         # options related to BUILDing the docker image:
@@ -68,5 +65,4 @@ jobs:
         platform: linux/amd64
         image: cmonitor
         # options related to PUSHing the docker image:
-        registry: ghcr.io
-        pushImage: false
+        pushImage: false # for now official docker images are published on DockerHub manually on new tags...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,3 +50,35 @@ jobs:
       run: make PROMETHEUS_SUPPORT=0
     - name: run unit tests
       run: make test PROMETHEUS_SUPPORT=0
+
+  alpine_docker_image_creation:
+    runs-on: ubuntu-latest
+
+    steps:
+    # # install deps
+    # - uses: actions/checkout@v4
+    # - name: install debian-packaged dependencies
+    #   run: sudo apt install -y libgtest-dev libbenchmark-dev libfmt-dev tidy git python3 python3-dateutil python3-pip
+    # - name: install pypi-packaged dependencies
+    #   run: sudo pip3 install pytest black
+
+    # # build & test
+    # - name: build cmonitor (with Prometheus support)
+    #   run: make PROMETHEUS_SUPPORT=0
+    # - name: run unit tests
+    #   run: make test PROMETHEUS_SUPPORT=0
+
+    - name: Build Docker image (no push)
+      # see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets
+      # for the reason why DependaBot pull requests have no access to secrets like ${{ secrets.PAT_TOKEN_FOR_GITHUB }}
+      # if: ${{ github.actor == 'dependabot[bot]' }}
+      uses: mr-smithers-excellent/docker-build-push@v6
+      with:
+        # options related to BUILDing the docker image:
+        dockerfile: ./collector/docker/Dockerfile.builder
+        multiPlatform: false
+        platform: linux/amd64
+        image: cmonitor
+        # options related to PUSHing the docker image:
+        registry: ghcr.io
+        pushImage: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       uses: mr-smithers-excellent/docker-build-push@v6
       with:
         # options related to BUILDing the docker image:
-        dockerfile: ./collector/docker/Dockerfile.builder
+        dockerfile: ./collector/docker/Dockerfile
         multiPlatform: false
         platform: linux/amd64
         image: cmonitor

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,19 +55,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # # install deps
-    # - uses: actions/checkout@v4
-    # - name: install debian-packaged dependencies
-    #   run: sudo apt install -y libgtest-dev libbenchmark-dev libfmt-dev tidy git python3 python3-dateutil python3-pip
-    # - name: install pypi-packaged dependencies
-    #   run: sudo pip3 install pytest black
-
-    # # build & test
-    # - name: build cmonitor (with Prometheus support)
-    #   run: make PROMETHEUS_SUPPORT=0
-    # - name: run unit tests
-    #   run: make test PROMETHEUS_SUPPORT=0
-
+    - uses: actions/checkout@v4
     - name: Build Docker image (no push)
       # see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets
       # for the reason why DependaBot pull requests have no access to secrets like ${{ secrets.PAT_TOKEN_FOR_GITHUB }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,4 +66,5 @@ jobs:
         platform: linux/amd64
         image: cmonitor
         # options related to PUSHing the docker image:
+        registry: docker.io
         pushImage: false # for now official docker images are published on DockerHub manually on new tags...

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,6 @@ valgrind:
 # DOCKER IMAGE
 #
 
-cmonitor_musl:
-	$(MAKE) -C collector cmonitor_musl
 docker_image:
 	$(MAKE) -C collector docker_image
 docker_run:

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -26,6 +26,8 @@ test_debug:
 	
 clean:
 	$(MAKE) -C src clean
+	rm -rf bin/musl
+	rm -rf bin/glibc
 
 strip:
 	$(MAKE) -C src strip
@@ -107,29 +109,12 @@ endif
 # DOCKER IMAGE
 # 
 
-cmonitor_musl: # build cmonitor inside a Docker from Alpine distro, to build a cmonitor_collector musl-linked
-	@# use a Docker to compile inside an Alpine environment:
-	docker build \
-		--tag f18m/cmonitor_builder:latest \
-		-f docker/Dockerfile.builder \
-		docker/
-	@# NOTE: by default debug symbols are embedded in the binary (to support COPR builds) but
-	#        for docker builds, we strip them away to reduce docker size:
-	docker run \
-		--rm -it \
-		-v "${ROOT_DIR}":"/opt/src" \
-		-e "MUSL_BUILD=1" -e "DISABLE_BENCHMARKS_BUILD=1" \
-		f18m/cmonitor_builder:latest \
-		sh -c "cd /opt/src/collector && gcc --version && make clean && make -j && make strip"
-
-docker_image: cmonitor_musl
-	@cp -fv bin/musl/cmonitor_collector docker
-	docker build \
+docker_image: # build cmonitor inside a Docker from Alpine distro, to build a cmonitor_collector musl-linked
+	cd .. && \
+		docker build \
 		--tag f18m/cmonitor:$(DOCKER_TAG) \
-		--build-arg sampling_interval=3 \
-		--build-arg num_samples=0 \
-		-f docker/Dockerfile \
-		docker
+			-f collector/docker/Dockerfile \
+			.
 
 docker_run:
 	@docker rm cmonitor-baremetal-collector >/dev/null 2>&1 || true

--- a/collector/docker/DockerHOWTO.md
+++ b/collector/docker/DockerHOWTO.md
@@ -20,8 +20,14 @@ This project supports only **Linux x86_64 architectures**.
 The cmonitor Docker image exposes a shared volume under /perf, so you can mount a host directory to that point to access the generated JSON file (if using JSON output mode). A typical invocation of the container might be:
 
 ```
-    @docker run 
+    docker run -d \
+        --rm \
         --name=cmonitor-baremetal-collector \
-        -v /root:/perf \
-        f18m/cmonitor
+        --network=host \
+        --pid=host \
+        --volume=/sys:/sys:ro \
+        --volume=/etc/os-release:/etc/os-release:ro \
+        --volume=$(pwd):/perf:rw \
+        f18m/cmonitor:latest \
+        --sampling-interval=1  ...
 ```

--- a/collector/docker/Dockerfile
+++ b/collector/docker/Dockerfile
@@ -1,9 +1,31 @@
-# NOTE: the version of Alpine used here must be aligned with the one in Dcokerfile.builder
-FROM alpine:3.20.2
+# This Dockerfile uses a multi-stage build to create the cmonitor_collector utility
 
-# make sure you did run the "cmonitor_musl" target before building this image:
+# Stage 1: Build stage
+FROM alpine:3.20.2 AS builder
+
+# Install necessary dependencies for building
+RUN apk update && apk add --no-cache binutils make libgcc musl-dev gcc g++ fmt-dev gtest-dev git
+
+# Set a working directory inside the container
+WORKDIR /opt/src/cmonitor
+
+# Copy all source files from the host to the working directory in the builder stage
+COPY . .
+
+# Build the cmonitor_collector utility, clean up, and strip debug symbols
+RUN git config --global --add safe.directory /opt/src && \
+    cd /opt/src/cmonitor/collector && \
+    make -j MUSL_BUILD=1 DISABLE_BENCHMARKS_BUILD=1 && \
+    make MUSL_BUILD=1 strip 
+
+
+# Stage 2: Final stage
+FROM alpine:3.20.2 AS final
+
 RUN apk add libstdc++ libc6-compat fmt-dev
-COPY cmonitor_collector /usr/bin/
+
+# Copy the built binary from the builder stage to the final stage
+COPY --from=builder /opt/src/cmonitor/collector/bin/musl/cmonitor_collector /usr/bin/
 
 # finally run the cmonitor collector 
 #  - in foreground since Docker does not like daemons

--- a/collector/docker/Dockerfile
+++ b/collector/docker/Dockerfile
@@ -12,7 +12,9 @@ WORKDIR /opt/src/cmonitor
 # Copy all source files from the host to the working directory in the builder stage
 COPY . .
 
-# Build the cmonitor_collector utility, clean up, and strip debug symbols
+# Build the cmonitor_collector utility and strip debug symbols
+# NOTE: by default debug symbols are embedded in the binary (to support COPR builds) but
+#        for docker builds, we strip them away to reduce docker size:
 RUN git config --global --add safe.directory /opt/src && \
     cd /opt/src/cmonitor/collector && \
     make -j MUSL_BUILD=1 DISABLE_BENCHMARKS_BUILD=1 && \

--- a/collector/docker/Dockerfile.builder
+++ b/collector/docker/Dockerfile.builder
@@ -1,5 +1,0 @@
-# This is just a small docker used to BUILD the cmonitor_collector utility
-
-FROM alpine:3.20.2
-RUN apk update && apk add --no-cache binutils make libgcc musl-dev gcc g++ fmt-dev gtest-dev git
-RUN git config --global --add safe.directory /opt/src


### PR DESCRIPTION
This PR is transforming the Dockerfile for the collector into a multistage docker to make it easier to build the docker image.
Additionally it's adding a step in the GH pipeline to validate that the docker image builds fine.