### PR TITLE
Fix Conan installation in CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,15 +18,17 @@ jobs:
     # install deps
     - uses: actions/checkout@v4
     - name: install debian-packaged dependencies
-      run: sudo apt install -y libgtest-dev libbenchmark-dev libfmt-dev tidy git python3 python3-dateutil python3-pip
+      run: sudo apt install -y libgtest-dev libbenchmark-dev libfmt-dev tidy git python3 python3-dateutil pipx
     - name: install pypi-packaged dependencies
-      run: sudo pip3 install pytest 'black==22.8.0' 'conan==2.14.0'
+      run: |
+        sudo pip3 install pytest 'black==22.8.0'
+        sudo pipx ensurepath
+        sudo pipx install 'conan==2.14.0'
 
     # NOTE: since we later run "make" using the normal "builder" user, we must use Conan using that same user (so avoid the "sudo"!!)
     - name: install Conan-packaged dependencies
       run: |
          conan profile detect --force
-         conan remote update conancenter --url https://center2.conan.io
          conan install conanfile.txt --build=missing
 
     # build & test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,14 @@ jobs:
     - name: run unit tests
       run: make test PROMETHEUS_SUPPORT=1
 
+    # save binary
+    - name: save built binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: cmonitor, Linux x86_64, Prometheus Support
+        path: collector/bin/glibc/cmonitor_collector
+        if-no-files-found: error
+
 
   build_test_without_prometheus_support:
     runs-on: ubuntu-latest
@@ -56,6 +64,14 @@ jobs:
       run: make PROMETHEUS_SUPPORT=0
     - name: run unit tests
       run: make test PROMETHEUS_SUPPORT=0
+
+    # save binary
+    - name: save built binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: cmonitor, Linux x86_64, No Prometheus Support
+        path: collector/bin/glibc/cmonitor_collector
+        if-no-files-found: error
 
   # this step is useful to check that the Dockerfile still works fine
   alpine_docker_image_creation:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     - name: install debian-packaged dependencies
       run: sudo apt install -y libgtest-dev libbenchmark-dev libfmt-dev tidy git python3 python3-dateutil python3-pip
     - name: install pypi-packaged dependencies
-      run: sudo pip3 install pytest 'black==22.8.0' 'conan==2.9.1'
+      run: sudo pip3 install pytest 'black==22.8.0' 'conan==2.14.0'
 
     # NOTE: since we later run "make" using the normal "builder" user, we must use Conan using that same user (so avoid the "sudo"!!)
     - name: install Conan-packaged dependencies


### PR DESCRIPTION
This PR is fixing the CI workflow that is installing Conan package manager to grab the Prometheus-cpp dependency.
Additionally it adds some step to save the built binary in the artifacts of the CI pipeline