### PR TITLE
Trigger COPR from GHA

### DIFF
--- a/.github/workflows/trigger-copr-build.yml
+++ b/.github/workflows/trigger-copr-build.yml
@@ -31,4 +31,7 @@ jobs:
 
     - name: Trigger COPR build
       run: |
-        copr-cli buildscm --type git --clone-url https://github.com/f18m/cmonitor.git --subdir collector --method make_srpm --commit ${{ github.head_ref || github.ref_name }} cmonitor
+        copr-cli buildscm \
+          --type git --clone-url https://github.com/f18m/cmonitor.git \
+          --subdir collector --method make_srpm --commit ${{ github.head_ref || github.ref_name }} \
+          cmonitor

--- a/.github/workflows/trigger-copr-build.yml
+++ b/.github/workflows/trigger-copr-build.yml
@@ -31,4 +31,4 @@ jobs:
 
     - name: Trigger COPR build
       run: |
-        copr-cli buildscm --type git --clone-url https://github.com/f18m/cmonitor.git --subdir collector --method make_srpm cmonitor
+        copr-cli buildscm --type git --clone-url https://github.com/f18m/cmonitor.git --subdir collector --method make_srpm --commit ${{ github.head_ref || github.ref_name }} cmonitor

--- a/.github/workflows/trigger-copr-build.yml
+++ b/.github/workflows/trigger-copr-build.yml
@@ -1,0 +1,34 @@
+name: trigger COPR
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  # add a cron job to run every month -- this project is not very active, at least ensure there's a valid CI build every month
+  # this is also useful to check if something breaks e.g. due to infrastructure changes (e.g. Ubuntu OS)
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  trigger_copr_build:
+    runs-on: ubuntu-latest
+
+    steps:
+    # install deps
+    - name: install COPR CLI
+      run: pip3 install copr-cli
+    
+    - name: Setup Copr config file
+      env:
+        # You need to have those secrets in your repo.
+        # See also: https://copr.fedorainfracloud.org/api/.
+        COPR_CONFIG: ${{ secrets.COPR_CONFIG }}
+      run: |
+        mkdir -p ~/.config
+        echo "$COPR_CONFIG" > ~/.config/copr
+
+    - name: Trigger COPR build
+      run: |
+        copr-cli buildscm --type git --clone-url https://github.com/f18m/cmonitor.git --subdir collector --method make_srpm cmonitor

--- a/.github/workflows/trigger-copr-build.yml
+++ b/.github/workflows/trigger-copr-build.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  trigger_copr_build:
+  copr_build_collector:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,9 +29,33 @@ jobs:
         mkdir -p ~/.config
         echo "$COPR_CONFIG" > ~/.config/copr
 
-    - name: Trigger COPR build
+    - name: Trigger COPR build [collector]
       run: |
         copr-cli buildscm \
           --type git --clone-url https://github.com/f18m/cmonitor.git \
           --subdir collector --method make_srpm --commit ${{ github.head_ref || github.ref_name }} \
+          cmonitor
+
+  copr_build_tools:
+    runs-on: ubuntu-latest
+
+    steps:
+    # install deps
+    - name: install COPR CLI
+      run: pip3 install copr-cli
+    
+    - name: Setup Copr config file
+      env:
+        # You need to have those secrets in your repo.
+        # See also: https://copr.fedorainfracloud.org/api/.
+        COPR_CONFIG: ${{ secrets.COPR_CONFIG }}
+      run: |
+        mkdir -p ~/.config
+        echo "$COPR_CONFIG" > ~/.config/copr
+
+    - name: Trigger COPR build [tools]
+      run: |
+        copr-cli buildscm \
+          --type git --clone-url https://github.com/f18m/cmonitor.git \
+          --subdir tools --method make_srpm --commit ${{ github.head_ref || github.ref_name }} \
           cmonitor

--- a/collector/spec/collector.spec
+++ b/collector/spec/collector.spec
@@ -77,3 +77,8 @@ rm -rf %{buildroot}
 
 %files
 %{_bindir}/cmonitor_collector
+
+%changelog
+
+* Thu Mar 27 2025 Francesco Montorsi <francesco.montorsi@gmail.com>
+- Fixed RPM build for Fedora 42 with this changelog entry   


### PR DESCRIPTION
This PR is adding a CI pipeline that will trigger COPR to build both the cmonitor_collector and cmonitor_tools RPMs and report back into Github the green/red status